### PR TITLE
writeglTF now writes the buffer(s) as well as the JSON.  

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rgl2gltf
 Type: Package
 Title: Read and Write .gltf and .glb Files
-Version: 0.1.12
+Version: 0.1.13
 Authors@R: c(person("Duncan", "Murdoch", role = c("aut", "cre"),
                      email = "murdoch.duncan@gmail.com"),
              person("Morten S.", "Mikkelsen", role = c("cph")))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# rgl2gltf 0.1.12
+# rgl2gltf 0.1.13
 
 * Added a `NEWS.md` file to track changes to the package.
 * Added "rigid" method animation to `playgltf()`.
@@ -11,3 +11,5 @@
 * Added `getTangents()` to use MikkTSpace code to assign tangents 
 if they are not specified.  These can be used in normal textures.
 * Textures may now be specified in JPEG format, not just PNG.
+* `writeglTF()` now writes the binary part of the file as
+well as the JSON part.

--- a/man/writeglTF.Rd
+++ b/man/writeglTF.Rd
@@ -10,7 +10,7 @@ files.  These functions write a \code{"gltf"}
 object to one of these formats.
 }
 \usage{
-writeglTF(x, path)
+writeglTF(x, path, bin = TRUE)
 writeGLB(x, con)
 }
 \arguments{
@@ -20,12 +20,22 @@ A \code{"gltf"} object, e.g. from \code{\link{as.gltf}}.
   \item{path}{
 A filename in which to write the JSON part of the file.
 }
+  \item{bin}{logical; whether or not to write the binary
+part of the object.}
   \item{con}{
 A filename or connection to which to write the GLB file.
   }
 }
+\details{
+If \code{bin = TRUE} (the default),
+\code{writeglTF} will write the binary part of the object
+to one or more separate files with filename constructed by
+concatenating the main part of \code{path}, followed by a number
+and the extension \file{.bin}.
+}
 \value{
-Both functions return \code{NULL} invisibly.
+\code{writeglTF} returns \code{path} invisibly.
+\code{writeGLB} returns \code{NULL} invisibly.
 }
 \references{
 The specification of the glTF format:


### PR DESCRIPTION
Fixes #34.